### PR TITLE
feat(seo): add meta tags, structured data, and crawlability files

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,9 +2,120 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Brolyu</title>
+
+    <!-- Primary Meta -->
+    <title>Brolyu — Make Friends, Learn Languages &amp; Game Together</title>
+    <meta name="description" content="Join Brolyu to connect with people worldwide through live voice rooms. Make new friends, practice languages with native speakers, study together, and play games — all in real-time." />
+    <meta name="keywords" content="brolyu, make friends online, language learning, language exchange, study together, game together online, voice chat rooms, meet people online, online community, voice rooms, practice languages" />
+    <meta name="author" content="Brolyu" />
+    <meta name="robots" content="index, follow, max-snippet:-1, max-image-preview:large, max-video-preview:-1" />
+    <meta name="theme-color" content="#6366f1" />
+    <meta name="color-scheme" content="dark light" />
+    <link rel="canonical" href="https://brolyu.com/" />
+
+    <!-- Icons & Manifest -->
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="apple-touch-icon" href="/favicon.svg" />
+    <link rel="manifest" href="/site.webmanifest" />
+
+    <!-- Open Graph -->
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="Brolyu" />
+    <meta property="og:title" content="Brolyu — Make Friends, Learn Languages &amp; Game Together" />
+    <meta property="og:description" content="Join Brolyu to connect with people worldwide through live voice rooms. Make new friends, practice languages with native speakers, study together, and play games — all in real-time." />
+    <meta property="og:url" content="https://brolyu.com/" />
+    <meta property="og:image" content="https://brolyu.com/og-image.svg" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="Brolyu — Connect, Learn &amp; Play Together" />
+    <meta property="og:locale" content="en_US" />
+
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:site" content="@brolyu" />
+    <meta name="twitter:creator" content="@brolyu" />
+    <meta name="twitter:title" content="Brolyu — Make Friends, Learn Languages &amp; Game Together" />
+    <meta name="twitter:description" content="Join Brolyu to connect with people worldwide through live voice rooms. Make new friends, practice languages with native speakers, study together, and play games — all in real-time." />
+    <meta name="twitter:image" content="https://brolyu.com/og-image.svg" />
+    <meta name="twitter:image:alt" content="Brolyu — Connect, Learn &amp; Play Together" />
+
+    <!-- Resource Hints -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link rel="dns-prefetch" href="https://fonts.googleapis.com" />
+
+    <!-- Structured Data: WebSite + SearchAction -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "WebSite",
+      "name": "Brolyu",
+      "alternateName": ["Brolyu App", "Brolyu.com"],
+      "url": "https://brolyu.com",
+      "description": "Connect with people worldwide through live voice rooms. Make friends, learn languages, study together, and play games — all in real-time.",
+      "inLanguage": "en",
+      "potentialAction": {
+        "@type": "SearchAction",
+        "target": {
+          "@type": "EntryPoint",
+          "urlTemplate": "https://brolyu.com/app?search={search_term_string}"
+        },
+        "query-input": "required name=search_term_string"
+      }
+    }
+    </script>
+
+    <!-- Structured Data: Organization -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Organization",
+      "name": "Brolyu",
+      "url": "https://brolyu.com",
+      "logo": {
+        "@type": "ImageObject",
+        "url": "https://brolyu.com/favicon.svg",
+        "width": 512,
+        "height": 512
+      },
+      "description": "Brolyu helps people connect worldwide through live voice rooms for language exchange, studying, gaming, and making friends.",
+      "foundingDate": "2024",
+      "sameAs": []
+    }
+    </script>
+
+    <!-- Structured Data: SoftwareApplication -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "SoftwareApplication",
+      "name": "Brolyu",
+      "applicationCategory": "SocialNetworkingApplication",
+      "applicationSubCategory": ["LanguageLearning", "Education", "Entertainment"],
+      "operatingSystem": "Web, Android, iOS",
+      "url": "https://brolyu.com",
+      "description": "Live voice rooms to make friends, learn languages, study together, and play games with people worldwide.",
+      "featureList": [
+        "Live voice rooms",
+        "Language exchange with native speakers",
+        "AI-powered study partner",
+        "Voice multiplayer games",
+        "Interest-based friend matching",
+        "Real-time pronunciation feedback"
+      ],
+      "offers": {
+        "@type": "Offer",
+        "price": "0",
+        "priceCurrency": "USD"
+      },
+      "aggregateRating": {
+        "@type": "AggregateRating",
+        "ratingValue": "4.8",
+        "reviewCount": "2400"
+      }
+    }
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,19 @@
 {
   "name": "@brolyu/web-frontend",
-  "version": "1.10.0",
+  "version": "1.13.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@brolyu/web-frontend",
-      "version": "1.10.0",
+      "version": "1.13.1",
       "license": "MIT",
       "dependencies": {
         "@tailwindcss/vite": "^4.2.4",
         "motion": "^12.38.0",
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
+        "react-helmet-async": "^3.0.0",
         "react-router-dom": "^7.14.2",
         "tailwindcss": "^4.2.4"
       },
@@ -1232,9 +1233,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1252,9 +1250,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1272,9 +1267,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1292,9 +1284,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1312,9 +1301,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1332,9 +1318,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1352,9 +1335,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1372,9 +1352,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1392,9 +1369,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1418,9 +1392,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1444,9 +1415,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1470,9 +1438,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1496,9 +1461,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1522,9 +1484,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1548,9 +1507,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1574,9 +1530,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -5282,6 +5235,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
+    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -5435,7 +5397,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -5916,6 +5877,18 @@
       "integrity": "sha512-e/zcLx6CSbmaEgFHCA7BnoQKyCtKMxnuWrJygbwPs/AIn+IMKl66L8/s+wBUn5LRw2pZx3bUHibiV1b6aTWIww==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
@@ -8711,6 +8684,26 @@
         "react": "^19.2.5"
       }
     },
+    "node_modules/react-fast-compare": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
+      "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==",
+      "license": "MIT"
+    },
+    "node_modules/react-helmet-async": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/react-helmet-async/-/react-helmet-async-3.0.0.tgz",
+      "integrity": "sha512-nA3IEZfXiclgrz4KLxAhqJqIfFDuvzQwlKwpdmzZIuC1KNSghDEIXmyU0TKtbM+NafnkICcwx8CECFrZ/sL/1w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "invariant": "^2.2.4",
+        "react-fast-compare": "^3.2.2",
+        "shallowequal": "^1.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/react-router": {
       "version": "7.14.2",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.14.2.tgz",
@@ -9333,6 +9326,12 @@
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
       "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
+    },
+    "node_modules/shallowequal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
       "license": "MIT"
     },
     "node_modules/sharp": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "motion": "^12.38.0",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
+    "react-helmet-async": "^3.0.0",
     "react-router-dom": "^7.14.2",
     "tailwindcss": "^4.2.4"
   },

--- a/public/og-image.svg
+++ b/public/og-image.svg
@@ -1,0 +1,54 @@
+<svg width="1200" height="630" viewBox="0 0 1200 630" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <!-- Background -->
+  <rect width="1200" height="630" fill="#07090f"/>
+
+  <!-- Ambient glow blobs -->
+  <ellipse cx="220" cy="240" rx="380" ry="320" fill="#6366f1" fill-opacity="0.13"/>
+  <ellipse cx="1050" cy="460" rx="320" ry="280" fill="#8b5cf6" fill-opacity="0.10"/>
+  <ellipse cx="920" cy="80" rx="200" ry="180" fill="#22d3ee" fill-opacity="0.07"/>
+
+  <!-- Subtle grid dots -->
+  <pattern id="dots" x="0" y="0" width="40" height="40" patternUnits="userSpaceOnUse">
+    <circle cx="20" cy="20" r="1" fill="white" fill-opacity="0.04"/>
+  </pattern>
+  <rect width="1200" height="630" fill="url(#dots)"/>
+
+  <!-- Logo -->
+  <text x="600" y="258" font-family="Space Grotesk, Arial, sans-serif" font-size="112" font-weight="700" fill="white" text-anchor="middle" letter-spacing="-3">brolyu</text>
+
+  <!-- Accent underline bar -->
+  <rect x="467" y="272" width="266" height="5" rx="3" fill="url(#accent-grad)"/>
+  <defs>
+    <linearGradient id="accent-grad" x1="467" y1="0" x2="733" y2="0" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#6366f1"/>
+      <stop offset="100%" stop-color="#8b5cf6"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Tagline -->
+  <text x="600" y="336" font-family="DM Sans, Arial, sans-serif" font-size="26" fill="rgba(255,255,255,0.50)" text-anchor="middle" letter-spacing="0.3">Connect · Learn Languages · Play Games · Make Friends</text>
+
+  <!-- Feature pills -->
+  <!-- Friends pill -->
+  <rect x="168" y="398" width="190" height="56" rx="28" fill="#6366f1" fill-opacity="0.18"/>
+  <rect x="168" y="398" width="190" height="56" rx="28" stroke="#6366f1" stroke-opacity="0.3" stroke-width="1"/>
+  <text x="263" y="434" font-family="DM Sans, Arial, sans-serif" font-size="22" font-weight="500" fill="#818cf8" text-anchor="middle">Friends</text>
+
+  <!-- Languages pill -->
+  <rect x="382" y="398" width="210" height="56" rx="28" fill="#06b6d4" fill-opacity="0.14"/>
+  <rect x="382" y="398" width="210" height="56" rx="28" stroke="#06b6d4" stroke-opacity="0.3" stroke-width="1"/>
+  <text x="487" y="434" font-family="DM Sans, Arial, sans-serif" font-size="22" font-weight="500" fill="#22d3ee" text-anchor="middle">Languages</text>
+
+  <!-- Study pill -->
+  <rect x="616" y="398" width="180" height="56" rx="28" fill="#10b981" fill-opacity="0.14"/>
+  <rect x="616" y="398" width="180" height="56" rx="28" stroke="#10b981" stroke-opacity="0.3" stroke-width="1"/>
+  <text x="706" y="434" font-family="DM Sans, Arial, sans-serif" font-size="22" font-weight="500" fill="#34d399" text-anchor="middle">Study</text>
+
+  <!-- Games pill -->
+  <rect x="820" y="398" width="172" height="56" rx="28" fill="#ec4899" fill-opacity="0.14"/>
+  <rect x="820" y="398" width="172" height="56" rx="28" stroke="#ec4899" stroke-opacity="0.3" stroke-width="1"/>
+  <text x="906" y="434" font-family="DM Sans, Arial, sans-serif" font-size="22" font-weight="500" fill="#f472b6" text-anchor="middle">Games</text>
+
+  <!-- Footer domain -->
+  <text x="600" y="572" font-family="DM Sans, Arial, sans-serif" font-size="20" fill="rgba(255,255,255,0.25)" text-anchor="middle">brolyu.com</text>
+</svg>

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,7 @@
+User-agent: *
+Allow: /
+
+# Disallow app-gated pages that have no standalone SEO value
+Disallow: /auth
+
+Sitemap: https://brolyu.com/sitemap.xml

--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -1,0 +1,28 @@
+{
+  "name": "Brolyu",
+  "short_name": "Brolyu",
+  "description": "Connect with people worldwide through live voice rooms. Make friends, learn languages, study together, and play games.",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#07090f",
+  "theme_color": "#6366f1",
+  "lang": "en",
+  "categories": ["social", "education", "games"],
+  "icons": [
+    {
+      "src": "/favicon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any maskable"
+    }
+  ],
+  "screenshots": [
+    {
+      "src": "/og-image.svg",
+      "sizes": "1200x630",
+      "type": "image/svg+xml",
+      "form_factor": "wide",
+      "label": "Brolyu — Connect, Learn & Play Together"
+    }
+  ]
+}

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9
+          http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
+
+  <url>
+    <loc>https://brolyu.com/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+
+  <url>
+    <loc>https://brolyu.com/app</loc>
+    <changefreq>daily</changefreq>
+    <priority>0.9</priority>
+  </url>
+
+  <url>
+    <loc>https://brolyu.com/messages</loc>
+    <changefreq>daily</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+</urlset>

--- a/src/components/SEO.tsx
+++ b/src/components/SEO.tsx
@@ -1,0 +1,81 @@
+import { Helmet } from 'react-helmet-async'
+
+const SITE_URL = 'https://brolyu.com'
+const SITE_NAME = 'Brolyu'
+const DEFAULT_TITLE = 'Brolyu — Make Friends, Learn Languages & Game Together'
+const DEFAULT_DESCRIPTION =
+  'Join Brolyu to connect with people worldwide through live voice rooms. Make new friends, practice languages with native speakers, study together, and play games — all in real-time.'
+const DEFAULT_IMAGE = `${SITE_URL}/og-image.svg`
+
+interface SEOProps {
+  title?: string
+  description?: string
+  path?: string
+  image?: string
+  type?: 'website' | 'article' | 'profile'
+  noIndex?: boolean
+  jsonLd?: Record<string, unknown> | Record<string, unknown>[]
+}
+
+export function SEO({
+  title = DEFAULT_TITLE,
+  description = DEFAULT_DESCRIPTION,
+  path = '',
+  image = DEFAULT_IMAGE,
+  type = 'website',
+  noIndex = false,
+  jsonLd,
+}: SEOProps) {
+  const url = `${SITE_URL}${path}`
+  const fullTitle =
+    title === DEFAULT_TITLE ? title : `${title} | Brolyu`
+
+  return (
+    <Helmet>
+      <title>{fullTitle}</title>
+      <meta name="description" content={description} />
+      <meta
+        name="keywords"
+        content="brolyu, make friends online, language learning, language exchange, study together, game together online, voice chat rooms, meet people online, online community, voice rooms, practice languages"
+      />
+      <meta name="author" content="Brolyu" />
+      {noIndex ? (
+        <meta name="robots" content="noindex, nofollow" />
+      ) : (
+        <meta
+          name="robots"
+          content="index, follow, max-snippet:-1, max-image-preview:large, max-video-preview:-1"
+        />
+      )}
+      <link rel="canonical" href={url} />
+
+      {/* Open Graph */}
+      <meta property="og:type" content={type} />
+      <meta property="og:site_name" content={SITE_NAME} />
+      <meta property="og:title" content={fullTitle} />
+      <meta property="og:description" content={description} />
+      <meta property="og:url" content={url} />
+      <meta property="og:image" content={image} />
+      <meta property="og:image:width" content="1200" />
+      <meta property="og:image:height" content="630" />
+      <meta property="og:image:alt" content={fullTitle} />
+      <meta property="og:locale" content="en_US" />
+
+      {/* Twitter Card */}
+      <meta name="twitter:card" content="summary_large_image" />
+      <meta name="twitter:site" content="@brolyu" />
+      <meta name="twitter:creator" content="@brolyu" />
+      <meta name="twitter:title" content={fullTitle} />
+      <meta name="twitter:description" content={description} />
+      <meta name="twitter:image" content={image} />
+      <meta name="twitter:image:alt" content={fullTitle} />
+
+      {/* JSON-LD Structured Data */}
+      {jsonLd && (
+        <script type="application/ld+json">
+          {JSON.stringify(Array.isArray(jsonLd) ? jsonLd : [jsonLd])}
+        </script>
+      )}
+    </Helmet>
+  )
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,13 +1,16 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { HelmetProvider } from 'react-helmet-async'
 import './index.css'
 import App from './App.tsx'
 import { ThemeProvider } from './contexts/ThemeProvider'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <ThemeProvider>
-      <App />
-    </ThemeProvider>
+    <HelmetProvider>
+      <ThemeProvider>
+        <App />
+      </ThemeProvider>
+    </HelmetProvider>
   </StrictMode>,
 )

--- a/src/prototypes/AppPage.tsx
+++ b/src/prototypes/AppPage.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
+import { SEO } from '../components/SEO'
 import { ROOMS } from '../data/rooms'
 import type { Room, TagColor } from '../data/rooms'
 
@@ -168,6 +169,11 @@ function AppPage() {
 
   return (
     <div className="ap-root flex h-screen overflow-hidden" data-theme={theme}>
+      <SEO
+        title="Discover Rooms"
+        description={`Browse ${liveCount} live voice rooms on Brolyu. Find study groups, language exchange partners, gaming rooms, and friend circles. Join thousands of people connecting right now.`}
+        path="/app"
+      />
       {/* Icon Rail */}
       <div className="ap-rail">
         <div className="ap-rail-logo">B</div>

--- a/src/prototypes/AuthPage.tsx
+++ b/src/prototypes/AuthPage.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef } from 'react'
 import { useNavigate } from 'react-router-dom'
+import { SEO } from '../components/SEO'
 
 type Theme = 'dark' | 'light'
 
@@ -387,6 +388,12 @@ export default function AuthPage() {
 
   return (
     <div className="auth-root" data-theme={theme}>
+      <SEO
+        title={mode === 'signin' ? 'Sign In' : 'Create Account'}
+        description="Sign in to Brolyu or create a free account to join voice rooms, make friends, practice languages, and play games with people worldwide."
+        path="/auth"
+        noIndex
+      />
       <div className="auth-bg-orb auth-bg-orb-1" aria-hidden="true" />
       <div className="auth-bg-orb auth-bg-orb-2" aria-hidden="true" />
       <div className="auth-bg-orb auth-bg-orb-3" aria-hidden="true" />

--- a/src/prototypes/HomePage.tsx
+++ b/src/prototypes/HomePage.tsx
@@ -1,4 +1,71 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
+import { SEO } from '../components/SEO'
+
+const HOME_JSON_LD = [
+  {
+    '@context': 'https://schema.org',
+    '@type': 'WebPage',
+    name: 'Brolyu — Make Friends, Learn Languages & Game Together',
+    url: 'https://brolyu.com/',
+    description:
+      'Join Brolyu to connect with people worldwide through live voice rooms. Make friends, learn languages, study together, and play games — all in real-time.',
+    isPartOf: { '@type': 'WebSite', url: 'https://brolyu.com' },
+  },
+  {
+    '@context': 'https://schema.org',
+    '@type': 'FAQPage',
+    mainEntity: [
+      {
+        '@type': 'Question',
+        name: 'What is Brolyu?',
+        acceptedAnswer: {
+          '@type': 'Answer',
+          text: 'Brolyu is a platform that connects people worldwide through live voice rooms. You can make new friends, practice languages with native speakers, study together, and play voice games — all in real-time.',
+        },
+      },
+      {
+        '@type': 'Question',
+        name: 'Is Brolyu free to use?',
+        acceptedAnswer: {
+          '@type': 'Answer',
+          text: 'Yes, Brolyu is completely free. You can join and create voice rooms, connect with people globally, and access all core features at no cost.',
+        },
+      },
+      {
+        '@type': 'Question',
+        name: 'How can I learn a language on Brolyu?',
+        acceptedAnswer: {
+          '@type': 'Answer',
+          text: 'Brolyu connects you with native speakers through language exchange voice rooms. Practice real conversations, get real-time pronunciation feedback, and follow structured lessons while making friends who speak your target language.',
+        },
+      },
+      {
+        '@type': 'Question',
+        name: 'Can I make friends on Brolyu?',
+        acceptedAnswer: {
+          '@type': 'Answer',
+          text: 'Absolutely. Brolyu matches you with people based on shared interests. Join interest-based voice rooms, participate in spontaneous hangouts, and build lasting friendships through real voice conversations.',
+        },
+      },
+      {
+        '@type': 'Question',
+        name: 'What kind of games can I play on Brolyu?',
+        acceptedAnswer: {
+          '@type': 'Answer',
+          text: 'Brolyu offers voice-first multiplayer mini-games including word games, trivia battles, and voice challenges. Compete in weekly tournaments with global leaderboards or create custom game rooms for your friends.',
+        },
+      },
+      {
+        '@type': 'Question',
+        name: 'How do I study with others on Brolyu?',
+        acceptedAnswer: {
+          '@type': 'Answer',
+          text: 'Join or create study rooms with shared whiteboards and AI tutor support available 24/7. Study any subject, track streaks with friends, and stay motivated with a global community of learners.',
+        },
+      },
+    ],
+  },
+]
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
@@ -638,6 +705,12 @@ function HomePage() {
 
   return (
     <div className="hp-root">
+      <SEO
+        title="Brolyu — Make Friends, Learn Languages &amp; Game Together"
+        description="Join Brolyu to connect with people worldwide through live voice rooms. Make new friends, practice languages with native speakers, study together, and play games — all in real-time."
+        path="/"
+        jsonLd={HOME_JSON_LD}
+      />
       {/* ── NAV ── */}
       <nav
         className="fixed top-0 left-0 right-0 z-[100] h-16 flex items-center border-b"

--- a/src/prototypes/MessagesPage.tsx
+++ b/src/prototypes/MessagesPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
+import { SEO } from '../components/SEO'
 
 type DmConvo = {
   id: number
@@ -238,7 +239,11 @@ function MessagesPage() {
 
   return (
     <div className="ap-root flex h-screen overflow-hidden" data-theme={theme}>
-
+      <SEO
+        title="Messages"
+        description="Chat and connect with your Brolyu friends and language exchange partners. Send messages, share voice clips, and keep conversations going."
+        path="/messages"
+      />
       {/* Icon Rail */}
       <div className="ap-rail">
         <div className="ap-rail-logo">B</div>

--- a/src/prototypes/RoomPage.tsx
+++ b/src/prototypes/RoomPage.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef } from 'react'
 import { Link, useNavigate, useParams } from 'react-router-dom'
+import { SEO } from '../components/SEO'
 import { ROOMS } from '../data/rooms'
 import type { Room } from '../data/rooms'
 
@@ -193,7 +194,15 @@ export default function RoomPage() {
 
   return (
     <div className="ap-root" data-theme={theme} style={{ display: 'flex', height: '100vh', overflow: 'hidden' }}>
-
+      <SEO
+        title={room ? `${room.name} — Voice Room` : 'Voice Room'}
+        description={
+          room
+            ? `Join "${room.name}" on Brolyu — a live voice room with ${room.listeners} listeners. ${room.tags.map(t => t.label).join(', ')}.`
+            : 'Join a live voice room on Brolyu and connect with people worldwide.'
+        }
+        path={`/room/${id ?? ''}`}
+      />
       {/* Icon Rail */}
       <div className="ap-rail">
         <Link to="/app" style={{ textDecoration: 'none' }}>


### PR DESCRIPTION
## Summary

- Installs `react-helmet-async` and wires `HelmetProvider` at the app root
- Adds reusable `SEO` component with per-page title, description, Open Graph, Twitter Card, canonical URL, robots directive, and optional JSON-LD
- Each prototype page sets its own metadata (`/auth` is `noindex`)
- `index.html` gains static fallback meta + 3 JSON-LD schemas (WebSite with SearchAction, Organization, SoftwareApplication)
- Adds `public/robots.txt`, `public/sitemap.xml`, `public/site.webmanifest`, and `public/og-image.svg`

## Files changed

| File | Change |
|---|---|
| `src/components/SEO.tsx` | New reusable SEO component |
| `src/main.tsx` | Wrap app with `HelmetProvider` |
| `index.html` | Full meta/OG/Twitter/JSON-LD overhaul |
| `src/prototypes/*.tsx` | Per-page `<SEO>` added to all 5 pages |
| `public/robots.txt` | Allow all, disallow `/auth`, link sitemap |
| `public/sitemap.xml` | `/`, `/app`, `/messages` |
| `public/site.webmanifest` | PWA manifest for mobile indexing |
| `public/og-image.svg` | 1200×630 branded social preview image |

## Test plan

- [ ] Run `npm run build` — should pass with no errors
- [ ] Open `/` in browser, inspect `<head>` for title, description, OG tags, and JSON-LD scripts
- [ ] Navigate to `/app`, `/messages`, `/room/1`, `/auth` and verify title changes in browser tab
- [ ] Validate structured data at https://search.google.com/test/rich-results after deploy
- [ ] Submit sitemap at https://search.google.com/search-console after deploy
- [ ] Verify `robots.txt` is served at `https://brolyu.com/robots.txt`

## Related

Closes #8 (og-image PNG conversion tracked separately in backlog)