### PR TITLE
chore(env): point production build at api.brolyu.com

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=https://api.brolyu.com


### PR DESCRIPTION
## Summary
Bakes \`VITE_API_BASE_URL=https://api.brolyu.com\` into production builds via a committed \`.env.production\`. Without this, \`vite build\` was falling through to the localhost default in \`src/lib/api.ts:35\`, so the deployed bundle was talking to a non-public dev backend.

## Test plan
- [x] CF Workers Builds picks up the push and runs \`npm run build && npx wrangler deploy\`.
- [x] Open https://brolyu.com in an incognito window. DevTools → Network → confirm \`fetch\` calls go to \`https://api.brolyu.com/...\`.
- [x] Click Google login on the deployed frontend; flow completes through \`api.brolyu.com\` and lands on \`https://brolyu.com/auth/callback\`.