### PR TITLE
fix(auth): prevent sign-in flash on guest-accessible routes

### DIFF
--- a/src/contexts/AuthProvider.tsx
+++ b/src/contexts/AuthProvider.tsx
@@ -8,16 +8,15 @@ interface Props {
 
 export function AuthProvider({ children }: Props) {
   const [user, setUser] = useState<User | null>(null)
-  const [loading, setLoading] = useState(true)
+  // Only enter the loading state when there's a token to validate. Without
+  // this, guest-accessible routes (e.g. /app) render their signed-out UI for
+  // a tick before swapping in the authed UI on hydrate.
+  const [loading, setLoading] = useState(() => tokenStore.get() !== null)
 
   useEffect(() => {
+    if (!loading) return
     let cancelled = false
     async function hydrate() {
-      const token = tokenStore.get()
-      if (!token) {
-        setLoading(false)
-        return
-      }
       try {
         const me = await api.me()
         if (!cancelled) setUser(me)
@@ -31,6 +30,8 @@ export function AuthProvider({ children }: Props) {
     return () => {
       cancelled = true
     }
+    // Hydration runs once on mount; `loading` is only read for the initial guard.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   const signInWithEmail = useCallback(async (email: string) => {

--- a/src/layouts/AppShell.tsx
+++ b/src/layouts/AppShell.tsx
@@ -6,7 +6,7 @@ import { useTheme } from '../contexts/useTheme'
 
 function AppShell() {
   const { theme, toggleTheme } = useTheme()
-  const { user, signOut } = useAuth()
+  const { user, loading, signOut } = useAuth()
   const { pathname } = useLocation()
   const navigate = useNavigate()
   const isApp = pathname === '/app'
@@ -72,7 +72,9 @@ function AppShell() {
           >
             {theme === 'dark' ? '☀️' : '🌙'}
           </button>
-          {user ? (
+          {loading ? (
+            <div className="ap-rail-avatar opacity-60" aria-hidden="true" />
+          ) : user ? (
             <div className="relative">
               <button
                 ref={triggerRef}


### PR DESCRIPTION
## Summary
- `AuthProvider` always started with `loading=true` and only resolved after `GET /auth/me`. Because `/app` is guest-accessible (not gated by `RequireAuth`), `AppShell` rendered the **Sign in** button for one tick and then swapped it for the user's avatar once hydration finished.
- Initialize `loading` from `tokenStore` so guests render their final state immediately on first paint.
- Render an avatar-shaped placeholder in `AppShell` while hydrating with a token present, so signed-in users never see the wrong button.

## Test plan
- [ ] Visit `/app` while signed out → "Sign in" renders immediately, no flash.
- [ ] Visit `/app` while signed in (token in `localStorage`) → neutral avatar placeholder briefly, then real avatar; **no** "Sign in" flash.
- [ ] `npm run lint` and `npm run build` pass.