### PR TITLE
fix(app): stop topbar reflow during auth hydration

### DIFF
--- a/src/pages/AppPage.tsx
+++ b/src/pages/AppPage.tsx
@@ -149,8 +149,11 @@ function RoomCard({ room, index }: { room: Room; index: number }) {
 function AppPage() {
   const [filter, setFilter] = useState('All')
   const [search, setSearch] = useState('')
-  const { user } = useAuth()
+  const { user, loading } = useAuth()
   const navigate = useNavigate()
+  // While auth is hydrating with a stored token, reserve space as if the
+  // user is signed in so the topbar doesn't reflow when /auth/me resolves.
+  const reserveAuthed = !!user || loading
 
   function handleCreateRoom() {
     if (!user) {
@@ -184,7 +187,7 @@ function AppPage() {
       {/* Topbar */}
       <div
         className={`shrink-0 pt-[18px] md:pt-[22px] pl-4 md:pl-8 ${
-          user ? 'pr-[64px] md:pr-[110px]' : 'pr-[150px] md:pr-[170px]'
+          reserveAuthed ? 'pr-[64px] md:pr-[110px]' : 'pr-[150px] md:pr-[170px]'
         }`}
       >
         <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between mb-4 md:mb-5">


### PR DESCRIPTION
## Summary
- The `/app` topbar reserves a wider right pad for the "Sign in" button when signed out (`pr-[150px] md:pr-[170px]`) and a narrower one for the avatar cluster when signed in (`pr-[64px] md:pr-[110px]`).
- While `AuthProvider` hydrated, `user` was null for a tick, so the topbar rendered with the signed-out pad and then snapped to the signed-in pad once `/auth/me` resolved — the **Create Room** button visibly shifted right.
- Treat `(user || loading)` as "render the signed-in layout" so the pad matches the eventual state from first paint when a token is present. Pairs with #14, which initializes `loading` from `tokenStore` (so `loading=true` reliably implies an authed-shaped end state).

## Test plan
- [ ] Hard-refresh `/app` while signed in → "Create Room" button stays put through hydration; no horizontal shift.
- [ ] Hard-refresh `/app` while signed out → topbar pad is the wider one immediately, no shift.
- [ ] Token in storage but `/auth/me` returns 401 → topbar settles into the signed-out layout once hydration fails (small acceptable shift, real signed-out state).
- [ ] `npm run lint` and `npm run build` pass.