### PR TITLE
feat(rooms): wire rooms list, detail, create, and end to API

### DIFF
--- a/src/data/rooms.ts
+++ b/src/data/rooms.ts
@@ -8,7 +8,7 @@ export type Speaker = {
 }
 
 export type Room = {
-  id: number
+  id: string
   name: string
   live: boolean
   strip: string
@@ -21,7 +21,7 @@ export type Room = {
 
 export const ROOMS: Room[] = [
   {
-    id: 1, name: "Let's talk in English", live: true,
+    id: '1', name: "Let's talk in English", live: true,
     strip: 'linear-gradient(90deg,#6366f1,#8b5cf6)',
     speakers: [
       { initial: 'H', color: '#6366f1', name: 'Hussein', speaking: true },
@@ -32,7 +32,7 @@ export const ROOMS: Room[] = [
     listeners: 12, category: 'Language',
   },
   {
-    id: 2, name: 'Spanish × Japanese Exchange 🌏', live: true,
+    id: '2', name: 'Spanish × Japanese Exchange 🌏', live: true,
     strip: 'linear-gradient(90deg,#0ea5e9,#06b6d4)',
     speakers: [
       { initial: 'P', color: '#0ea5e9', name: 'Pablo', speaking: true },
@@ -43,7 +43,7 @@ export const ROOMS: Room[] = [
     listeners: 8, category: 'Language',
   },
   {
-    id: 3, name: 'IELTS Prep — AI Study Hall 📚', live: true,
+    id: '3', name: 'IELTS Prep — AI Study Hall 📚', live: true,
     strip: 'linear-gradient(90deg,#f59e0b,#f97316)',
     speakers: [
       { initial: 'J', color: '#f59e0b', name: 'Ji-su', speaking: true },
@@ -53,7 +53,7 @@ export const ROOMS: Room[] = [
     listeners: 34, category: 'Study',
   },
   {
-    id: 4, name: 'Word Blitz Battle 🎮 — Round 7', live: true,
+    id: '4', name: 'Word Blitz Battle 🎮 — Round 7', live: true,
     strip: 'linear-gradient(90deg,#ec4899,#f43f5e)',
     speakers: [
       { initial: 'Z', color: '#ec4899', name: 'Zara', speaking: true },
@@ -65,7 +65,7 @@ export const ROOMS: Room[] = [
     listeners: 6, category: 'Games',
   },
   {
-    id: 5, name: 'Chill Korean Corner ☕', live: true,
+    id: '5', name: 'Chill Korean Corner ☕', live: true,
     strip: 'linear-gradient(90deg,#8b5cf6,#a78bfa)',
     speakers: [
       { initial: 'E', color: '#8b5cf6', name: 'Eun', speaking: true },
@@ -76,7 +76,7 @@ export const ROOMS: Room[] = [
     listeners: 19, category: 'Language',
   },
   {
-    id: 6, name: 'Make Friends from Anywhere 🌍', live: true,
+    id: '6', name: 'Make Friends from Anywhere 🌍', live: true,
     strip: 'linear-gradient(90deg,#14b8a6,#06b6d4)',
     speakers: [
       { initial: 'N', color: '#14b8a6', name: 'Nadia', speaking: true },
@@ -86,7 +86,7 @@ export const ROOMS: Room[] = [
     listeners: 27, category: 'Friends',
   },
   {
-    id: 7, name: 'French for Beginners 🇫🇷', live: false,
+    id: '7', name: 'French for Beginners 🇫🇷', live: false,
     strip: 'linear-gradient(90deg,#3b82f6,#60a5fa)',
     speakers: [
       { initial: 'C', color: '#3b82f6', name: 'Camille' },
@@ -96,7 +96,7 @@ export const ROOMS: Room[] = [
     listeners: 0, category: 'Language', startsIn: 'in 20 min',
   },
   {
-    id: 8, name: 'Deep Talks — Philosophy & Life 🧠', live: true,
+    id: '8', name: 'Deep Talks — Philosophy & Life 🧠', live: true,
     strip: 'linear-gradient(90deg,#6366f1,#06b6d4)',
     speakers: [
       { initial: 'A', color: '#6366f1', name: 'Alex', speaking: true },
@@ -107,7 +107,7 @@ export const ROOMS: Room[] = [
     listeners: 41, category: 'Friends',
   },
   {
-    id: 9, name: 'Trivia Night — General Knowledge 🏆', live: true,
+    id: '9', name: 'Trivia Night — General Knowledge 🏆', live: true,
     strip: 'linear-gradient(90deg,#f59e0b,#ec4899)',
     speakers: [
       { initial: 'T', color: '#f59e0b', name: 'Tiago', speaking: true },
@@ -118,7 +118,7 @@ export const ROOMS: Room[] = [
     listeners: 22, category: 'Games',
   },
   {
-    id: 10, name: 'Spanish × Japanese Exchange 🌏', live: true,
+    id: '10', name: 'Spanish × Japanese Exchange 🌏', live: true,
     strip: 'linear-gradient(90deg,#0ea5e9,#06b6d4)',
     speakers: [
       { initial: 'P', color: '#0ea5e9', name: 'Pablo', speaking: true },
@@ -129,7 +129,7 @@ export const ROOMS: Room[] = [
     listeners: 8, category: 'Language',
   },
   {
-    id: 11, name: 'IELTS Prep — AI Study Hall 📚', live: true,
+    id: '11', name: 'IELTS Prep — AI Study Hall 📚', live: true,
     strip: 'linear-gradient(90deg,#f59e0b,#f97316)',
     speakers: [
       { initial: 'J', color: '#f59e0b', name: 'Ji-su', speaking: true },
@@ -139,7 +139,7 @@ export const ROOMS: Room[] = [
     listeners: 34, category: 'Study',
   },
   {
-    id: 12, name: 'Word Blitz Battle 🎮 — Round 7', live: true,
+    id: '12', name: 'Word Blitz Battle 🎮 — Round 7', live: true,
     strip: 'linear-gradient(90deg,#ec4899,#f43f5e)',
     speakers: [
       { initial: 'Z', color: '#ec4899', name: 'Zara', speaking: true },

--- a/src/features/rooms/CreateRoomModal.tsx
+++ b/src/features/rooms/CreateRoomModal.tsx
@@ -1,0 +1,329 @@
+import { useState, type FormEvent } from 'react'
+import { ApiError } from '../../lib/api'
+import { roomsApi } from './api'
+import type { ApiRoom } from './api'
+
+interface Props {
+  onCreated: (room: ApiRoom) => void
+  onClose: () => void
+}
+
+const CATEGORIES: { slug: string; label: string; icon: string }[] = [
+  { slug: 'language-exchange', label: 'Language', icon: '🌐' },
+  { slug: 'study', label: 'Study', icon: '📚' },
+  { slug: 'games', label: 'Games', icon: '🎮' },
+  { slug: 'friends', label: 'Friends', icon: '👋' },
+  { slug: 'music', label: 'Music', icon: '🎵' },
+]
+
+const LANGUAGES: { code: string; label: string; flag: string }[] = [
+  { code: 'en', label: 'English', flag: '🇬🇧' },
+  { code: 'es', label: 'Spanish', flag: '🇪🇸' },
+  { code: 'ja', label: 'Japanese', flag: '🇯🇵' },
+  { code: 'ko', label: 'Korean', flag: '🇰🇷' },
+  { code: 'fr', label: 'French', flag: '🇫🇷' },
+]
+
+export function CreateRoomModal({ onCreated, onClose }: Props) {
+  const [name, setName] = useState('')
+  const [categorySlug, setCategorySlug] = useState<string>('')
+  const [primaryLangCode, setPrimaryLangCode] = useState('en')
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const canSubmit = !submitting && name.trim().length >= 2
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault()
+    if (submitting) return
+    setError(null)
+    setSubmitting(true)
+    try {
+      const room = await roomsApi.create({
+        name: name.trim(),
+        categorySlug: categorySlug || undefined,
+        primaryLangCode: primaryLangCode || undefined,
+      })
+      onCreated(room)
+    } catch (err) {
+      const msg =
+        err instanceof ApiError
+          ? err.message
+          : err instanceof Error
+            ? err.message
+            : 'Could not create room'
+      setError(msg)
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      style={{
+        background: 'oklch(0% 0 0 / 0.55)',
+        backdropFilter: 'blur(8px)',
+        WebkitBackdropFilter: 'blur(8px)',
+        animation: 'rp-fadeIn 0.2s ease both',
+      }}
+      onClick={onClose}
+    >
+      <form
+        onSubmit={handleSubmit}
+        onClick={e => e.stopPropagation()}
+        className="relative w-full max-w-md p-6 flex flex-col gap-5 overflow-hidden"
+        style={{
+          background:
+            'linear-gradient(180deg, var(--bg2) 0%, var(--bg) 100%)',
+          border: '1px solid var(--border)',
+          borderRadius: 'var(--radius-lg, 24px)',
+          boxShadow:
+            '0 24px 60px -20px rgba(0,0,0,0.6), 0 0 0 1px var(--border2), 0 0 80px -20px var(--color-accent-glow)',
+          animation: 'ap-card-in 0.32s cubic-bezier(0.34,1.1,0.64,1) both',
+        }}
+      >
+        {/* accent glow */}
+        <div
+          aria-hidden
+          className="pointer-events-none absolute"
+          style={{
+            top: -80,
+            left: -80,
+            width: 240,
+            height: 240,
+            background:
+              'radial-gradient(circle, var(--color-accent-glow) 0%, transparent 65%)',
+            filter: 'blur(8px)',
+          }}
+        />
+        <div
+          aria-hidden
+          className="pointer-events-none absolute"
+          style={{
+            top: -60,
+            right: -60,
+            width: 200,
+            height: 200,
+            background:
+              'radial-gradient(circle, oklch(62% 0.22 300 / 0.25) 0%, transparent 65%)',
+            filter: 'blur(8px)',
+          }}
+        />
+
+        <div className="relative flex items-start justify-between">
+          <div className="flex items-center gap-3">
+            <div
+              className="flex items-center justify-center"
+              style={{
+                width: 40,
+                height: 40,
+                borderRadius: 12,
+                background:
+                  'linear-gradient(135deg, var(--color-accent), var(--color-accent2))',
+                boxShadow: '0 8px 24px -8px var(--color-accent-glow)',
+                fontSize: 20,
+              }}
+            >
+              🎙️
+            </div>
+            <div className="flex flex-col">
+              <h2
+                className="font-display text-[20px] font-bold tracking-[-0.5px] leading-tight"
+                style={{ color: 'var(--text)' }}
+              >
+                Start a Room
+              </h2>
+              <span
+                className="text-[12px]"
+                style={{ color: 'var(--text-m)' }}
+              >
+                Go live in seconds
+              </span>
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            className="flex items-center justify-center cursor-pointer transition-all"
+            style={{
+              width: 32,
+              height: 32,
+              borderRadius: 10,
+              background: 'var(--surface)',
+              border: '1px solid var(--border)',
+              color: 'var(--text-m)',
+              fontSize: 14,
+            }}
+            onMouseEnter={e => {
+              e.currentTarget.style.background = 'var(--surface2)'
+              e.currentTarget.style.color = 'var(--text)'
+            }}
+            onMouseLeave={e => {
+              e.currentTarget.style.background = 'var(--surface)'
+              e.currentTarget.style.color = 'var(--text-m)'
+            }}
+          >
+            ✕
+          </button>
+        </div>
+
+        <label className="relative flex flex-col gap-2">
+          <span
+            className="text-[11px] font-semibold uppercase tracking-[0.6px]"
+            style={{ color: 'var(--text-m)' }}
+          >
+            Room name
+          </span>
+          <input
+            value={name}
+            onChange={e => setName(e.target.value)}
+            placeholder="What are you talking about?"
+            required
+            minLength={2}
+            maxLength={120}
+            autoFocus
+            className="rounded-xl border px-4 py-3 text-[14px] outline-none transition-colors"
+            style={{
+              background: 'var(--surface)',
+              borderColor: 'var(--border)',
+              color: 'var(--text)',
+            }}
+            onFocus={e => {
+              e.currentTarget.style.borderColor = 'var(--color-accent)'
+              e.currentTarget.style.background = 'var(--surface2)'
+            }}
+            onBlur={e => {
+              e.currentTarget.style.borderColor = 'var(--border)'
+              e.currentTarget.style.background = 'var(--surface)'
+            }}
+          />
+        </label>
+
+        <div className="relative flex flex-col gap-2">
+          <span
+            className="text-[11px] font-semibold uppercase tracking-[0.6px]"
+            style={{ color: 'var(--text-m)' }}
+          >
+            Category <span style={{ color: 'var(--text-d)' }}>· optional</span>
+          </span>
+          <div className="flex flex-wrap gap-2">
+            {CATEGORIES.map(c => {
+              const active = categorySlug === c.slug
+              return (
+                <button
+                  type="button"
+                  key={c.slug}
+                  onClick={() =>
+                    setCategorySlug(active ? '' : c.slug)
+                  }
+                  className="flex items-center gap-1.5 px-3 py-2 rounded-full text-[13px] font-semibold cursor-pointer transition-all"
+                  style={{
+                    background: active
+                      ? 'oklch(62% 0.22 265 / 0.16)'
+                      : 'var(--surface)',
+                    border: `1px solid ${
+                      active ? 'var(--color-accent)' : 'var(--border)'
+                    }`,
+                    color: active ? 'var(--color-accent)' : 'var(--text-m)',
+                    boxShadow: active
+                      ? '0 4px 16px -6px var(--color-accent-glow)'
+                      : 'none',
+                  }}
+                >
+                  <span style={{ fontSize: 14 }}>{c.icon}</span>
+                  {c.label}
+                </button>
+              )
+            })}
+          </div>
+        </div>
+
+        <div className="relative flex flex-col gap-2">
+          <span
+            className="text-[11px] font-semibold uppercase tracking-[0.6px]"
+            style={{ color: 'var(--text-m)' }}
+          >
+            Primary language
+          </span>
+          <div className="flex flex-wrap gap-2">
+            {LANGUAGES.map(l => {
+              const active = primaryLangCode === l.code
+              return (
+                <button
+                  type="button"
+                  key={l.code}
+                  onClick={() => setPrimaryLangCode(l.code)}
+                  className="flex items-center gap-1.5 px-3 py-2 rounded-full text-[13px] font-semibold cursor-pointer transition-all"
+                  style={{
+                    background: active
+                      ? 'oklch(62% 0.22 265 / 0.16)'
+                      : 'var(--surface)',
+                    border: `1px solid ${
+                      active ? 'var(--color-accent)' : 'var(--border)'
+                    }`,
+                    color: active ? 'var(--color-accent)' : 'var(--text-m)',
+                    boxShadow: active
+                      ? '0 4px 16px -6px var(--color-accent-glow)'
+                      : 'none',
+                  }}
+                >
+                  <span style={{ fontSize: 14 }}>{l.flag}</span>
+                  {l.label}
+                </button>
+              )
+            })}
+          </div>
+        </div>
+
+        {error && (
+          <div
+            className="relative text-[12px] rounded-lg px-3 py-2.5 border flex items-start gap-2"
+            style={{
+              background: 'oklch(62% 0.22 25 / 0.1)',
+              borderColor: 'oklch(62% 0.22 25 / 0.25)',
+              color: 'oklch(72% 0.18 25)',
+            }}
+          >
+            <span style={{ fontSize: 13, lineHeight: '16px' }}>⚠</span>
+            <span>{error}</span>
+          </div>
+        )}
+
+        <div className="relative flex justify-end gap-2 pt-1">
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={submitting}
+            className="px-4 py-2.5 rounded-xl border text-[13px] font-semibold cursor-pointer transition-colors"
+            style={{
+              background: 'var(--surface)',
+              borderColor: 'var(--border)',
+              color: 'var(--text)',
+            }}
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={!canSubmit}
+            className="px-5 py-2.5 rounded-xl text-[13px] font-bold cursor-pointer text-white transition-all"
+            style={{
+              background: canSubmit
+                ? 'linear-gradient(135deg, var(--color-accent), var(--color-accent2))'
+                : 'oklch(62% 0.22 265 / 0.4)',
+              boxShadow: canSubmit
+                ? '0 8px 24px -8px var(--color-accent-glow), inset 0 1px 0 rgba(255,255,255,0.18)'
+                : 'none',
+              opacity: canSubmit ? 1 : 0.7,
+              cursor: canSubmit ? 'pointer' : 'not-allowed',
+            }}
+          >
+            {submitting ? 'Starting…' : 'Go Live →'}
+          </button>
+        </div>
+      </form>
+    </div>
+  )
+}

--- a/src/features/rooms/api.ts
+++ b/src/features/rooms/api.ts
@@ -1,0 +1,136 @@
+import { ApiError, tokenStore } from '../../lib/api'
+import type { Room, TagColor } from '../../data/rooms'
+
+export interface ApiRoom {
+  publicId: string
+  name: string
+  description: string | null
+  category: { slug: string; label: string } | null
+  host: {
+    id: string
+    username: string
+    name: string
+    avatarUrl: string | null
+  }
+  primaryLangCode: string | null
+  visibility: 'public' | 'unlisted' | 'private'
+  status: 'live' | 'ended' | 'cancelled'
+  gradientFrom: string | null
+  gradientTo: string | null
+  maxSpeakers: number
+  allowVideo: boolean
+  allowScreenShare: boolean
+  isRecording: boolean
+  speakerCount: number
+  listenerCount: number
+  startedAt: string | null
+  endedAt: string | null
+  lastActivityAt: string
+  createdAt: string
+}
+
+export interface CreateRoomInput {
+  name: string
+  description?: string
+  categorySlug?: string
+  primaryLangCode?: string
+  gradientFrom?: string
+  gradientTo?: string
+}
+
+const BASE =
+  (import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:3000').replace(/\/$/, '') +
+  '/api/v1'
+
+async function request<T>(path: string, init: RequestInit = {}): Promise<T> {
+  const headers = new Headers(init.headers)
+  if (init.body && !headers.has('Content-Type')) {
+    headers.set('Content-Type', 'application/json')
+  }
+  const token = tokenStore.get()
+  if (token) headers.set('Authorization', `Bearer ${token}`)
+
+  const res = await fetch(`${BASE}${path}`, { ...init, headers })
+  const text = await res.text()
+  const data: unknown = text ? JSON.parse(text) : null
+
+  if (!res.ok) {
+    const msg =
+      (data && typeof data === 'object' && 'message' in data
+        ? String((data as { message: unknown }).message)
+        : null) ?? `Request failed (${res.status})`
+    throw new ApiError(res.status, msg)
+  }
+  return data as T
+}
+
+export const roomsApi = {
+  list: (categorySlug?: string) =>
+    request<ApiRoom[]>(
+      `/rooms${categorySlug ? `?category=${encodeURIComponent(categorySlug)}` : ''}`,
+    ),
+  get: (publicId: string) => request<ApiRoom>(`/rooms/${publicId}`),
+  create: (input: CreateRoomInput) =>
+    request<ApiRoom>('/rooms', { method: 'POST', body: JSON.stringify(input) }),
+  end: (publicId: string) =>
+    request<ApiRoom>(`/rooms/${publicId}/end`, { method: 'PATCH' }),
+}
+
+// Slug → frontend filter chip label. Anything not listed maps to itself.
+const CATEGORY_LABEL_BY_SLUG: Record<string, string> = {
+  'language-exchange': 'Language',
+  study: 'Study',
+  games: 'Games',
+  friends: 'Friends',
+  music: 'Music',
+}
+
+const FALLBACK_GRADIENT_FROM = '#6366f1'
+const FALLBACK_GRADIENT_TO = '#8b5cf6'
+
+// Map server room → existing UI Room shape. Speaker/tag arrays are
+// synthesised from host + category until the participants slice lands and
+// we have real per-participant data.
+export function apiRoomToUiRoom(r: ApiRoom): Room {
+  const from = r.gradientFrom ?? FALLBACK_GRADIENT_FROM
+  const to = r.gradientTo ?? FALLBACK_GRADIENT_TO
+  const initial = (r.host.name?.[0] ?? r.host.username[0] ?? '?').toUpperCase()
+  const tagColor: TagColor = pickTagColor(r.category?.slug)
+
+  return {
+    id: r.publicId,
+    name: r.name,
+    live: r.status === 'live',
+    strip: `linear-gradient(90deg,${from},${to})`,
+    speakers: [
+      {
+        initial,
+        color: from,
+        name: r.host.name || r.host.username,
+        speaking: r.status === 'live',
+      },
+    ],
+    tags: r.category
+      ? [{ label: r.category.label, color: tagColor }]
+      : [],
+    listeners: r.listenerCount,
+    category: r.category ? CATEGORY_LABEL_BY_SLUG[r.category.slug] ?? r.category.label : '',
+  }
+}
+
+function pickTagColor(slug: string | undefined): TagColor {
+  switch (slug) {
+    case 'language-exchange':
+      return 'blue'
+    case 'study':
+      return 'amber'
+    case 'games':
+      return 'rose'
+    case 'friends':
+      return 'purple'
+    case 'music':
+      return 'green'
+    default:
+      return 'blue'
+  }
+}

--- a/src/pages/AppPage.tsx
+++ b/src/pages/AppPage.tsx
@@ -1,9 +1,10 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { SEO } from '../components/SEO'
-import { ROOMS } from '../data/rooms'
 import type { Room, TagColor } from '../data/rooms'
 import { useAuth } from '../contexts/useAuth'
+import { apiRoomToUiRoom, roomsApi } from '../features/rooms/api'
+import { CreateRoomModal } from '../features/rooms/CreateRoomModal'
 
 const FILTERS = ['All', 'Language', 'Study', 'Games', 'Friends', 'Beginner', 'Advanced']
 
@@ -149,20 +150,46 @@ function RoomCard({ room, index }: { room: Room; index: number }) {
 function AppPage() {
   const [filter, setFilter] = useState('All')
   const [search, setSearch] = useState('')
+  const [rooms, setRooms] = useState<Room[]>([])
+  const [roomsLoading, setRoomsLoading] = useState(true)
+  const [roomsError, setRoomsError] = useState<string | null>(null)
+  const [createOpen, setCreateOpen] = useState(false)
   const { user, loading } = useAuth()
   const navigate = useNavigate()
   // While auth is hydrating with a stored token, reserve space as if the
   // user is signed in so the topbar doesn't reflow when /auth/me resolves.
   const reserveAuthed = !!user || loading
 
+  useEffect(() => {
+    let cancelled = false
+    roomsApi
+      .list()
+      .then(list => {
+        if (cancelled) return
+        setRooms(list.map(apiRoomToUiRoom))
+        setRoomsError(null)
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return
+        setRoomsError(err instanceof Error ? err.message : 'Could not load rooms')
+      })
+      .finally(() => {
+        if (!cancelled) setRoomsLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
   function handleCreateRoom() {
     if (!user) {
       navigate('/auth', { state: { from: '/app' } })
       return
     }
+    setCreateOpen(true)
   }
 
-  const filtered = ROOMS.filter(room => {
+  const filtered = rooms.filter(room => {
     const matchFilter =
       filter === 'All' ||
       room.category === filter ||
@@ -230,16 +257,26 @@ function AppPage() {
       {/* Rooms scroll */}
       <div className="ap-rooms-scroll flex-1 overflow-y-auto px-4 md:px-8 pb-8">
         <div className="ap-section-label">
-          {filter === 'All'
-            ? `${liveCount} live rooms`
-            : `${filtered.length} rooms · ${filter}`}
+          {roomsLoading
+            ? 'Loading rooms…'
+            : filter === 'All'
+              ? `${liveCount} live rooms`
+              : `${filtered.length} rooms · ${filter}`}
         </div>
+        {roomsError && !roomsLoading && (
+          <div
+            className="text-center py-10 text-[13px]"
+            style={{ color: 'oklch(62% 0.22 15)' }}
+          >
+            {roomsError}
+          </div>
+        )}
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
           {filtered.map((room, i) => (
             <RoomCard key={room.id} room={room} index={i} />
           ))}
         </div>
-        {filtered.length === 0 && (
+        {!roomsLoading && !roomsError && filtered.length === 0 && (
           <div
             className="text-center py-20 text-[14px]"
             style={{ color: 'var(--text-d)' }}
@@ -254,6 +291,16 @@ function AppPage() {
           </div>
         )}
       </div>
+
+      {createOpen && (
+        <CreateRoomModal
+          onClose={() => setCreateOpen(false)}
+          onCreated={room => {
+            setCreateOpen(false)
+            navigate(`/room/${room.publicId}`)
+          }}
+        />
+      )}
     </>
   )
 }

--- a/src/pages/RoomPage.tsx
+++ b/src/pages/RoomPage.tsx
@@ -1,8 +1,9 @@
 import { useState, useEffect, useRef } from 'react'
 import { Link, useNavigate, useParams } from 'react-router-dom'
 import { SEO } from '../components/SEO'
-import { ROOMS } from '../data/rooms'
 import type { Room } from '../data/rooms'
+import { useAuth } from '../contexts/useAuth'
+import { apiRoomToUiRoom, roomsApi, type ApiRoom } from '../features/rooms/api'
 
 type TagColor = 'blue' | 'green' | 'purple' | 'amber' | 'rose'
 
@@ -118,8 +119,13 @@ function RoomCard({ room, active, onClick }: { room: Room; active: boolean; onCl
 export default function RoomPage() {
   const { id } = useParams<{ id: string }>()
   const navigate = useNavigate()
+  const { user } = useAuth()
 
-  const room = ROOMS.find(r => r.id === Number(id))
+  const [apiRoom, setApiRoom] = useState<ApiRoom | null>(null)
+  const [room, setRoom] = useState<Room | null>(null)
+  const [roomLoading, setRoomLoading] = useState(true)
+  const [sidebarRooms, setSidebarRooms] = useState<Room[]>([])
+  const [endingRoom, setEndingRoom] = useState(false)
 
   const [sidebarOpen, setSidebarOpen]   = useState(true)
   const [chatOpen, setChatOpen]         = useState(false)
@@ -127,16 +133,68 @@ export default function RoomPage() {
   const [sidebarSearch, setSidebarSearch] = useState('')
   const [muted, setMuted]               = useState(false)
   const [activeSpeaker, setActiveSpeaker] = useState(0)
-  const [msgs, setMsgs]                 = useState<ChatMessage[]>(() => room ? buildInitialMessages(room) : [])
+  const [msgs, setMsgs]                 = useState<ChatMessage[]>([])
   const [inputVal, setInputVal]         = useState('')
   const [copied, setCopied]             = useState(false)
   const msgsEndRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!id) return
+    let cancelled = false
+    roomsApi
+      .get(id)
+      .then(api => {
+        if (cancelled) return
+        const ui = apiRoomToUiRoom(api)
+        setApiRoom(api)
+        setRoom(ui)
+        setMsgs(buildInitialMessages(ui))
+      })
+      .catch(() => {
+        if (cancelled) return
+        setApiRoom(null)
+        setRoom(null)
+      })
+      .finally(() => {
+        if (!cancelled) setRoomLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [id])
+
+  useEffect(() => {
+    let cancelled = false
+    roomsApi
+      .list()
+      .then(list => {
+        if (cancelled) return
+        setSidebarRooms(list.map(apiRoomToUiRoom))
+      })
+      .catch(() => {
+        // Sidebar is non-critical; swallow errors silently.
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
 
   useEffect(() => {
     if (!room) return
     const t = setInterval(() => setActiveSpeaker(s => (s + 1) % room.speakers.length), 2800)
     return () => clearInterval(t)
   }, [room])
+
+  async function handleEndRoom() {
+    if (!apiRoom || endingRoom) return
+    setEndingRoom(true)
+    try {
+      await roomsApi.end(apiRoom.publicId)
+      navigate('/app')
+    } catch {
+      setEndingRoom(false)
+    }
+  }
 
   useEffect(() => {
     msgsEndRef.current?.scrollIntoView({ behavior: 'smooth' })
@@ -160,7 +218,7 @@ export default function RoomPage() {
     setInputVal('')
   }
 
-  const filteredSidebar = ROOMS.filter(r => {
+  const filteredSidebar = sidebarRooms.filter(r => {
     const matchFilter =
       sidebarFilter === 'All Rooms' ||
       r.category === sidebarFilter ||
@@ -172,7 +230,15 @@ export default function RoomPage() {
     return matchFilter && matchSearch
   })
 
-  if (!room) {
+  if (roomLoading) {
+    return (
+      <div style={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center', color: 'var(--text-d)', fontSize: 14 }}>
+        Loading room…
+      </div>
+    )
+  }
+
+  if (!room || !apiRoom) {
     return (
       <div style={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center', flexDirection: 'column', gap: 16 }}>
         <div style={{ fontFamily: 'var(--font-display)', fontSize: 24, fontWeight: 700, color: 'var(--text)' }}>Room not found</div>
@@ -180,6 +246,8 @@ export default function RoomPage() {
       </div>
     )
   }
+
+  const isHost = !!user && apiRoom.host.id === user.id
 
   const speakers = room.speakers.map((s, i) => ({ ...s, speaking: i === activeSpeaker }))
   const visibleListeners = LISTENER_POOL.slice(0, Math.min(6, room.listeners))
@@ -265,6 +333,16 @@ export default function RoomPage() {
             <button className={`rp-copy-btn${copied ? ' copied' : ''}`} onClick={copyLink}>
               {copied ? '✓ Copied!' : '🔗 Copy Link'}
             </button>
+            {isHost && (
+              <button
+                className="rp-leave-btn"
+                onClick={handleEndRoom}
+                disabled={endingRoom}
+                style={{ background: 'oklch(62% 0.22 15)', color: 'white' }}
+              >
+                {endingRoom ? 'Ending…' : 'End Room ⏹'}
+              </button>
+            )}
             <button className="rp-leave-btn" onClick={() => navigate('/app')}>Leave ✕</button>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Replace the static `ROOMS` mock with live data from `roomsApi` (list/get/create/end).
- `AppPage` now fetches the room list on mount and opens a new `CreateRoomModal`; navigation jumps to the new room's `publicId` after creation.
- `RoomPage` loads a room by `publicId`, populates the sidebar from the API, and exposes an **End Room** action for the host.
- Widen `Room.id` from `number` to `string` so it matches API `publicId`s.

## Commits
- 6fef78d feat(rooms): wire rooms list, detail, create, and end to API

## Test plan
- [ ] Visit `/app` — rooms load from the API, error state renders if the request fails.
- [ ] Click **Create Room** while signed in — modal opens, submission navigates to the new room.
- [ ] Click **Create Room** while signed out — redirects to `/auth`.
- [ ] Open `/room/:publicId` — room hydrates, sidebar populates, missing rooms show the not-found state.
- [ ] As host, click **End Room** — request fires, navigation returns to `/app`.
- [ ] As non-host, **End Room** is hidden.